### PR TITLE
remove dump_datetime for serializing date

### DIFF
--- a/popcorn/helpers.py
+++ b/popcorn/helpers.py
@@ -26,13 +26,6 @@ from functools import wraps
 from flask import request, jsonify, render_template
 
 
-def dump_datetime(value):
-    """Serialize datetime object into string form for JSON processing."""
-    if value is None:
-        return None
-    return [value.strftime("%Y-%m-%d"), value.strftime("%H:%M:%S")]
-
-
 def request_wants_json():
     best = request.accept_mimetypes.best_match(['application/json',
                                                'text/html'])

--- a/popcorn/models/submission.py
+++ b/popcorn/models/submission.py
@@ -28,7 +28,6 @@ from sqlalchemy import Column, Date, ForeignKey, String
 from sqlalchemy.orm import relationship
 
 from popcorn.database import Base
-from popcorn.helpers import dump_datetime
 
 
 class SubmissionError(Exception):
@@ -56,7 +55,7 @@ class Submission(Base):
     @property
     def _flat_attrs(self):
         return {
-           'sub_date': dump_datetime(self.sub_date),
+           'sub_date': self.sub_date.strftime("%Y-%m-%d"),
            'sys_hwuuid': self.sys_hwuuid,
            'popcorn_version': self.popcorn_version,
         }

--- a/popcorn/models/submission_package.py
+++ b/popcorn/models/submission_package.py
@@ -27,7 +27,6 @@ from sqlalchemy.orm import relationship
 
 from popcorn.database import Base
 from popcorn.models import Submission
-from popcorn.helpers import dump_datetime
 
 
 class SubmissionPackage(Base):
@@ -100,7 +99,7 @@ class SubmissionPackage(Base):
     def _flat_attrs(self):
         return {
             'sys_hwuuid': self.sys_hwuuid,
-            'sub_date': dump_datetime(self.sub_date),
+            'sub_date': self.sub_date.strftime("%Y-%m-%d"),
             'pkg_name': self.pkg_name,
             'pkg_version': self.pkg_version,
             'pkg_release': self.pkg_release,

--- a/popcorn/test/test_views.py
+++ b/popcorn/test/test_views.py
@@ -151,7 +151,7 @@ class PopcornTestCase(unittest.TestCase):
                     "sys_hwuuid":
                         "677ec7c2-3b9e-4b25-8f45-b651d8bbb701",
                     "submissions": [{
-                        "sub_date": [today.strftime("%Y-%m-%d"), "00:00:00"],
+                        "sub_date": today.strftime("%Y-%m-%d"),
                         "sys_hwuuid":
                             "677ec7c2-3b9e-4b25-8f45-b651d8bbb701",
                         "popcorn_version": "0.1"
@@ -171,7 +171,7 @@ class PopcornTestCase(unittest.TestCase):
             self.assertEqual(json.loads(response.data), {
                 "packages": [{
                     "sys_hwuuid": "677ec7c2-3b9e-4b25-8f45-b651d8bbb701",
-                    "sub_date": [today.strftime("%Y-%m-%d"), "00:00:00"],
+                    "sub_date": today.strftime("%Y-%m-%d"),
                     "pkg_status": "voted",
                     "pkg_name": "sed",
                     "pkg_version": "4.2.1",
@@ -183,7 +183,7 @@ class PopcornTestCase(unittest.TestCase):
                 "voted": 1,
                 "generic_package": {
                     "sys_hwuuid": "677ec7c2-3b9e-4b25-8f45-b651d8bbb701",
-                    "sub_date": [today.strftime("%Y-%m-%d"), "00:00:00"],
+                    "sub_date": today.strftime("%Y-%m-%d"),
                     "pkg_status": "voted",
                     "pkg_name": "sed",
                     "pkg_version": "4.2.1",


### PR DESCRIPTION
since time is not stored in db, and sub_date is a primary key
dump_datetime is not required
- remove dump_datetime fn from helpers.py
- serialize date in models as string
- modify tests accordingly
